### PR TITLE
expose content length header

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -29,7 +29,9 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 
-app.use(cors())
+app.use(cors({
+    exposedHeaders: ['Content-Length']
+}))
 app.use(compression())
 app.use(morgan('combined', {stream: accessLogStream}))
 


### PR DESCRIPTION
Could @mosaic141688 please review this. 

The default behaviour is not to expose any custom headers, so this should not break anything.

I didn't test with actual data. But the test response to the root route now has a content length header, it didn't before.