### PR TITLE
Renaming unnamed plan to ‘Unnamed’

### DIFF
--- a/src/v7/lib/decorate_incoming_document.js
+++ b/src/v7/lib/decorate_incoming_document.js
@@ -1,7 +1,8 @@
 const decorate_incoming_document = ({doc, req}) => {
-  doc.personalised_instance_id = req.personalised_instance_id
-  doc.updated_at = (+new Date())
-  return doc
+    doc.personalised_instance_id = req.personalised_instance_id
+    doc.updated_at = (+new Date())
+    doc.name = doc.name ? doc.name : 'Unnamed'
+    return doc
 }
 
 module.exports = {decorate_incoming_document}


### PR DESCRIPTION
Name an incoming plan 'Unnamed' if it does not have a name property