### PR TITLE
Getting current plan should require read permission, not write

### DIFF
--- a/src/v7/index.js
+++ b/src/v7/index.js
@@ -79,7 +79,7 @@ const endpoints = [
         callback: plan.create
     },
     {
-        permissions: ['write:irs_plan'],
+        permissions: ['read:irs_plan'],
         method: GET,
         path: '/plan/current',
         callback: plan.get_current


### PR DESCRIPTION
Fixed an incorrect permission. 

Fixes bug experienced here: https://github.com/disarm-platform/user-requests-and-feedback/issues/93#issuecomment-408387015

Might be a good thing to check all permissions for all users before we go ahead and merge this in. 